### PR TITLE
Add packaging for Meteor.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,0 +1,23 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'driftyco:ionicons';
+var version = JSON.parse(Npm.require("fs").readFileSync('component.json')).version;
+
+Package.describe({
+    name: packageName,
+    summary: 'ionicons (official): The premium icon font for Ionic',
+    version: version,
+    git: 'https://github.com/driftyco/ionicons.git'
+});
+
+Package.onUse(function (api) {
+    api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+    api.addFiles([
+        'fonts/ionicons.eot',
+        'fonts/ionicons.svg',
+        'fonts/ionicons.ttf',
+        'fonts/ionicons.woff',
+        'css/ionicons.css'
+    ], 'client');
+});


### PR DESCRIPTION
Would be great to have official integration with [Meteor](https://github.com/meteor/meteor). This pull request includes meteor's package descriptor. 

Install meteor using:

```
curl https://install.meteor.com | /bin/sh
```

First time package publication:

```
meteor publish --create
```

On subsequent publications use just `meteor publish`.
Version is automatically kept in sync with `component.json`
