### PR TITLE
Added mixin for easier access of icons in custom style sheets

### DIFF
--- a/scss/ionicons.scss
+++ b/scss/ionicons.scss
@@ -13,3 +13,10 @@
 
 @import "ionicons-font";
 @import "ionicons-icons";
+
+@mixin ion-icon($icon-value) {
+  &:before {
+    @extend .ion;
+    content: $icon-value;
+  }
+}


### PR DESCRIPTION
Added mixin for easier access of icons in custom style sheets.

You can now use ionicons much easier in your SASS file like so:

```
@import "ionicons"

# ...

a.facebook-link
    +ion-icon($ionicon-var-social-facebook)
    # add some more styling, like colors, :hover, etc.

```