### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ We intend for this icon pack to be used with [Ionic](http://ionicframework.com/)
  4. Ensure the font urls within `ionicons.css` properly reference the `fonts` path within your project.
  5. Include a reference to the `ionicons.css` file from every webpage you need to use it.
 
-Or install with [component](https://github.com/component/component):
+Or install with [component](https://github.com/componentjs/component):
 
     $ component install driftyco/ionicons
     


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/component/component | https://github.com/componentjs/component 
